### PR TITLE
➕💄 Install TailwindCSS

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,8 +30,11 @@
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^5.43.0",
     "@typescript-eslint/parser": "^5.43.0",
+    "autoprefixer": "^10.4.13",
     "eslint-plugin-import": "^2.26.0",
+    "postcss": "^8.4.19",
     "prettier": "^2.7.1",
+    "tailwindcss": "^3.2.4",
     "typescript": "^4.9.3"
   },
   "browserslist": {

--- a/package.json
+++ b/package.json
@@ -116,5 +116,11 @@
     "semi": false,
     "trailingComma": "es5",
     "arrowParens": "avoid"
+  },
+  "postcss": {
+    "plugins": {
+      "tailwindcss": {},
+      "autoprefixer": {}
+    }
   }
 }

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,6 +1,0 @@
-module.exports = {
-  plugins: {
-    tailwindcss: {},
-    autoprefixer: {},
-  },
-}

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,9 +4,9 @@ import "./common/assets/styles/App.css"
 
 export function App(): JSX.Element {
   return (
-    <div className="App">
+    <div className="App bg-green-500">
       <header className="App-header">
-        <h1>Hiiiiii</h1>
+        <h1 className="text-amber-300">Hiiiii</h1>
         <img src={logo} className="App-logo" alt="logo" />
         <p>
           Edit <code>src/App.tsx</code> and save to reload.

--- a/src/index.css
+++ b/src/index.css
@@ -1,3 +1,7 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
 body {
   margin: 0;
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen",

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,8 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: ["./src/**/*.{js,jsx,ts,tsx}"],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+}


### PR DESCRIPTION
## Overview
Adds & configs TailwindCSS for easy UI styling
Closes #12

## Changes
- Install Tailwind, Postcss and autoprefixer
- Move Postcss configs into `package.json`, because it's only a few lines and should not clutter the top-level folder

## Risk
- Discovered that Tailwind classes don't seem to overwrite self-defined css classes